### PR TITLE
Add a message when search results are empty

### DIFF
--- a/frontend/src/views/c-authorship.vue
+++ b/frontend/src/views/c-authorship.vue
@@ -98,7 +98,7 @@
               span {{ ignoredFilesCount }} ignored file(s)
 
   .files(v-if="isLoaded")
-    .empty(v-if="info.files.length === 0") nothing to see here :(
+    .empty(v-if="selectedFiles.length === 0") nothing to see here :(
     template(v-for="(file, i) in selectedFiles", v-bind:key="file.path")
       .file(v-bind:ref="file.path")
         .title(v-bind:class="{'sticky':\ file.active}")


### PR DESCRIPTION
Currently, when the user Filters by Glob in the Code Panel, and the filter results are empty, an empty screen gets displayed as follows:
<img width="639" alt="Screenshot 2023-07-01 at 12 49 41 AM" src="https://github.com/pratham31012002/RepoSense/assets/71367149/2dc36991-619e-408c-88a4-2fd7e958e609">

Let's change this to display a message as follows:
<img width="622" alt="Screenshot 2023-07-01 at 12 49 01 AM" src="https://github.com/pratham31012002/RepoSense/assets/71367149/d026181f-43ce-43d8-8f7e-9da1d302ace2">

